### PR TITLE
TST: avoid a memory leak by closing the decoder

### DIFF
--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -24,4 +24,8 @@ fn open_dummy_cb() {
     let result =
         unsafe { ffi::mp3dec_ex_open_cb(decoder.as_mut_ptr(), &mut io, ffi::MP3D_SEEK_TO_SAMPLE) };
     assert_eq!(result, ffi::MP3D_E_IOERROR);
+    unsafe {
+        // Even though there was an IO error, we still have to free the reserved memory:
+        ffi::mp3dec_ex_close(decoder.as_mut_ptr());
+    }
 }


### PR DESCRIPTION
Thanks to @icmccorm for suggesting this fix!